### PR TITLE
Remove incorrect lib<>.dll prefix from windows

### DIFF
--- a/example_project/godot_egui.gdnlib
+++ b/example_project/godot_egui.gdnlib
@@ -9,7 +9,7 @@ reloadable=true
 
 X11.64="res://../target/debug/libgodot_egui_example.so"
 OSX.64="res://../target/debug/libgodot_egui_example.dylib"
-Windows.64="res://../target/debug/libgodot_egui_example.dll"
+Windows.64="res://../target/debug/godot_egui_example.dll"
 
 [dependencies]
 


### PR DESCRIPTION
When rust builds a dll on Windows it doesn't get a lib prefix like it does on macos or linux. Remove that from the name Godot is expecting for the example project.

Apart from that (and an issue with my out-of-date compiler) the example ran great!