### PR TITLE
Editor Plugin Examples using EGUI

### DIFF
--- a/example_project/GodotEguiExample.tscn
+++ b/example_project/GodotEguiExample.tscn
@@ -6,6 +6,8 @@
 [node name="GodotEguiExample" type="Control"]
 anchor_right = 1.0
 anchor_bottom = 1.0
+size_flags_horizontal = 3
+size_flags_vertical = 3
 script = ExtResource( 2 )
 __meta__ = {
 "_edit_use_anchors_": false
@@ -19,6 +21,8 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 scroll_speed = 20.0
+consume_mouse_events = true
 override_default_fonts = false
+disable_texture_filtering = false
 custom_font_1 = "res://fonts/fontawesome/Font Awesome 5 Free-Solid-900.otf"
 custom_font_2 = "res://fonts/bubblegum_sans/BubblegumSans-Regular.otf"

--- a/example_project/addons/egui_dock/eguidock.gd
+++ b/example_project/addons/egui_dock/eguidock.gd
@@ -1,0 +1,20 @@
+tool
+extends EditorPlugin
+
+# A class member to hold the dock during the plugin life cycle.
+const Dock = preload("res://GodotEguiExample.tscn")
+var dock_instance
+
+
+func _enter_tree():
+    dock_instance = Dock.instance()
+    # Add the main panel to the editor's main viewport.
+    add_control_to_dock(DOCK_SLOT_LEFT_UL, dock_instance)
+
+		
+func _exit_tree():
+    # Clean-up of the plugin goes here.
+    # Remove the dock.
+    remove_control_from_docks(dock_instance)
+    # Erase the control from the memory.
+    dock_instance.free()

--- a/example_project/addons/egui_dock/plugin.cfg
+++ b/example_project/addons/egui_dock/plugin.cfg
@@ -1,0 +1,7 @@
+[plugin]
+
+name="EGUI Dock"
+description="A Test dock with EGUI."
+author="jacobsky"
+version="0.1.6"
+script="eguidock.gd"

--- a/example_project/addons/egui_main_screen/egui_main_screen.gd
+++ b/example_project/addons/egui_main_screen/egui_main_screen.gd
@@ -1,0 +1,34 @@
+tool
+extends EditorPlugin
+
+# A class member to hold the dock during the plugin life cycle.
+const MainPanel = preload("res://GodotEguiExample.tscn")
+var main_panel_instance
+
+func _enter_tree():
+	main_panel_instance = MainPanel.instance()
+	# Add the main panel to the editor's main viewport.
+	get_editor_interface().get_editor_viewport().add_child(main_panel_instance)
+	# Hide the main panel. Very much required.
+	make_visible(false)
+
+		
+func _exit_tree():
+	if main_panel_instance:
+		main_panel_instance.queue_free()
+
+
+func has_main_screen():
+	return true
+
+
+func make_visible(visible):
+	if main_panel_instance:
+		main_panel_instance.visible = visible
+
+
+func get_plugin_name():
+	return "EGUI Plugin"
+
+func get_plugin_icon() -> Texture:
+    return get_editor_interface().get_base_control().get_icon("WindowDialog", "EditorIcons")

--- a/example_project/addons/egui_main_screen/plugin.cfg
+++ b/example_project/addons/egui_main_screen/plugin.cfg
@@ -1,0 +1,7 @@
+[plugin]
+
+name="EGUI Main Screen"
+description="A Test Main Screen with EGUI."
+author="jacobsky"
+version="0.1.6"
+script="egui_main_screen.gd"

--- a/example_project/src/lib.rs
+++ b/example_project/src/lib.rs
@@ -188,8 +188,8 @@ impl GodotEguiExample {
 }
 
 fn init(handle: InitHandle) {
-    handle.add_class::<GodotEguiExample>();
-    godot_egui::register_classes(handle);
+    handle.add_tool_class::<GodotEguiExample>();
+    godot_egui::register_classes_as_tool(handle);
 }
 
 godot_init!(init);

--- a/godot_egui/src/lib.rs
+++ b/godot_egui/src/lib.rs
@@ -381,4 +381,13 @@ impl GodotEgui {
     pub fn mouse_was_captured(&self) -> bool { self.mouse_was_captured }
 }
 
+/// Helper method that registers all GodotEgui `NativeClass` objects as scripts.
+/// ## Note
+/// This method should not be used in any library where `register_classes_as_tool` is run. Doing so may result in `gdnative` errors.
 pub fn register_classes(handle: InitHandle) { handle.add_class::<GodotEgui>(); }
+
+/// Helper method that registers all GodotEgui `NativeClass` objects as tool scripts. This should **only** be used when GodotEgui is to be run inside the Godot editor.
+/// ## Note
+/// This method should not be used in any library where `register_classes` is run. Doing so may result in `gdnative` errors. 
+pub fn register_classes_as_tool(handle: InitHandle) { handle.add_tool_class::<GodotEgui>(); }
+


### PR DESCRIPTION
Added two Editor Plugin samples by adding some tool scripts based on the Godot Tutorials.

This includes 
- Main Screen sample
- Dock sample

To make this work, the `GodotEguiExample` and `GodotEgui` NativeClasses needed to be registered as tool classes.

As discussed in Discord, converting the classes to tool scripts may have some issues related to hot reloading. Based on my testing, this only appears to affect godot if you are currently using the editor actively during a build while where the native library may be deleted.

I believe this can be mitigated in real projects by either

1. Developing toolscripts in a separate library so that they don't have to be rebuilt with your game.
2. Avoiding pointing directly where the libraries are built and instead copy the library into the project folder (manually or via an editor build task)

Let me know if you would like to include any changes. For the plugin .cfgs, I just left the author as myself, but if you'd like to change it, I don't have a problem with it :)