### PR TITLE
Fixed clippy lints

### DIFF
--- a/example_project/src/lib.rs
+++ b/example_project/src/lib.rs
@@ -35,11 +35,11 @@ impl GodotEguiExample {
     }
 
     #[export]
-    pub unsafe fn _ready(&mut self, owner: TRef<Control>) {
+    pub fn _ready(&mut self, owner: TRef<Control>) {
         godot_print!("Initializing godot egui");
         let gui = owner
             .get_node("GodotEgui")
-            .and_then(|godot_egui| godot_egui.assume_safe().cast::<Control>())
+            .and_then(|godot_egui| unsafe { godot_egui.assume_safe() }.cast::<Control>())
             .and_then(|godot_egui| godot_egui.cast_instance::<GodotEgui>())
             .expect("Expected a `GodotEgui` child with the GodotEgui nativescript class.");
 
@@ -66,8 +66,7 @@ impl GodotEguiExample {
 
         // A frame can be passed to `update` specifying background color, margin and other properties
         // You may also want to pass in `None` and draw a background using a regular Panel node instead.
-        let mut frame = egui::Frame::default();
-        frame.margin = egui::vec2(20.0, 20.0);
+        let frame = egui::Frame { margin: egui::vec2(20.0, 20.0), ..Default::default() };
 
         let mut should_reverse_font_priorities = false;
 

--- a/godot_egui/src/egui_helpers.rs
+++ b/godot_egui/src/egui_helpers.rs
@@ -24,7 +24,6 @@ pub fn progress_bar(ui: &mut egui::Ui, progress: f32) -> egui::Response {
     response
 }
 
-
 pub const NUMBER_KEYS: [egui::Key; 10] = [
     egui::Key::Num1,
     egui::Key::Num2,
@@ -38,7 +37,6 @@ pub const NUMBER_KEYS: [egui::Key; 10] = [
     egui::Key::Num0,
 ];
 
-
 pub trait ColorHelpers<T> {
     fn with_alpha(&self, alpha: T) -> Self;
     fn lightened(&self, amount: f32) -> Self;
@@ -47,7 +45,7 @@ impl ColorHelpers<u8> for egui::Color32 {
     fn with_alpha(&self, alpha: u8) -> Self {
         let mut color = *self;
         color[3] = alpha;
-        return color;
+        color
     }
     fn lightened(&self, amount: f32) -> Self {
         Self::from_rgba_premultiplied(
@@ -62,7 +60,7 @@ impl ColorHelpers<u8> for egui::Stroke {
     fn with_alpha(&self, alpha: u8) -> Self {
         let mut color = self.color;
         color[3] = alpha;
-        return Self { width: self.width, color };
+        Self { width: self.width, color }
     }
     fn lightened(&self, amount: f32) -> Self {
         Self { width: self.width, color: self.color.lightened(amount) }

--- a/godot_egui/src/enum_conversions.rs
+++ b/godot_egui/src/enum_conversions.rs
@@ -1,8 +1,7 @@
 use gdnative::api::GlobalConstants;
 
 pub fn scancode_to_egui(scancode: i64) -> Option<egui::Key> {
-
-    let key = match scancode {
+    match scancode {
         GlobalConstants::KEY_DOWN => Some(egui::Key::ArrowDown),
         GlobalConstants::KEY_LEFT => Some(egui::Key::ArrowLeft),
         GlobalConstants::KEY_RIGHT => Some(egui::Key::ArrowRight),
@@ -55,9 +54,7 @@ pub fn scancode_to_egui(scancode: i64) -> Option<egui::Key> {
         GlobalConstants::KEY_Y => Some(egui::Key::Y),
         GlobalConstants::KEY_Z => Some(egui::Key::Z),
         _ => None,
-    };
-
-    key
+    }
 }
 
 pub fn mouse_button_index_to_egui(button_index: i64) -> Option<egui::PointerButton> {


### PR DESCRIPTION
Fixed 3 deny clippy lints.
Fixed 7 Warn clippy lints
Allowed 1 deny clippy lint that was documented to be potentially unsound, but was considered to be a fine trade-off for the time being.

I tested it and it appears that these changes did not cause any regressions in the egui library. All of the changes were verbatim as of rust-stable 1.54.0.
