### PR TITLE
Fixed `_input` being falsely detected when a Godot GUI element is on top of the other element.

### DIFF
--- a/egui_stylist_addon/addons/egui_stylist/egui_stylist.tscn
+++ b/egui_stylist_addon/addons/egui_stylist/egui_stylist.tscn
@@ -16,6 +16,7 @@ __meta__ = {
 [node name="godot_egui" type="Control" parent="."]
 anchor_right = 1.0
 anchor_bottom = 1.0
+focus_mode = 1
 size_flags_horizontal = 3
 size_flags_vertical = 3
 script = ExtResource( 2 )

--- a/egui_stylist_addon/src/stylist.rs
+++ b/egui_stylist_addon/src/stylist.rs
@@ -1,5 +1,5 @@
 use egui_stylist::StylistState;
-use gdnative::api::{FileDialog};
+use gdnative::api::FileDialog;
 use gdnative::prelude::*;
 use godot_egui::GodotEgui;
 
@@ -16,6 +16,19 @@ impl GodotEguiStylist {
     fn new(_: &Control) -> Self {
         Self { style: StylistState::default(), godot_egui: None, file_dialog: None }
     }
+    
+    /// Updates egui from the `_gui_input` callback
+    #[export]
+    pub fn _gui_input(&mut self, owner: TRef<Control>, event: Ref<InputEvent>) {
+        let gui = unsafe { self.godot_egui.as_ref().expect("GUI initialized").assume_safe() };
+        gui.map_mut(|gui, instance| {
+            gui.handle_godot_input(instance, event, true);
+            if gui.mouse_was_captured(instance) {
+                owner.accept_event();
+            }
+        }).expect("map_mut should succeed");
+    }
+
     #[export]
     fn _ready(&mut self, owner: TRef<Control>) {
         let gui = owner

--- a/egui_stylist_addon/src/stylist.rs
+++ b/egui_stylist_addon/src/stylist.rs
@@ -16,7 +16,7 @@ impl GodotEguiStylist {
     fn new(_: &Control) -> Self {
         Self { style: StylistState::default(), godot_egui: None, file_dialog: None }
     }
-    
+
     /// Updates egui from the `_gui_input` callback
     #[export]
     pub fn _gui_input(&mut self, owner: TRef<Control>, event: Ref<InputEvent>) {
@@ -26,7 +26,8 @@ impl GodotEguiStylist {
             if gui.mouse_was_captured(instance) {
                 owner.accept_event();
             }
-        }).expect("map_mut should succeed");
+        })
+        .expect("map_mut should succeed");
     }
 
     #[export]
@@ -170,13 +171,9 @@ fn read_file(filepath: &str) -> String {
 pub fn load_theme(path: GodotString) -> egui_theme::EguiTheme {
     // Load the GodotEguiTheme via the ResourceLoader and then extract the EguiTheme
     let file_path = path.to_string();
-    
-    // We should allow for both godot resources as well as the vanilla .ron files to be published.
-    let theme = {
-        let file = read_file(&file_path);
-        ron::from_str(&file).expect("this should load")
-    };
-    theme
+
+    let file = read_file(&file_path);
+    ron::from_str(&file).expect("this should load")
 }
 
 pub fn save_theme(path: GodotString, theme: egui_theme::EguiTheme) {

--- a/example_project/GodotEguiExample.tscn
+++ b/example_project/GodotEguiExample.tscn
@@ -12,16 +12,18 @@ script = ExtResource( 2 )
 __meta__ = {
 "_edit_use_anchors_": false
 }
+handle_input = true
+handle_gui_input = false
 
 [node name="GodotEgui" type="Control" parent="."]
 anchor_right = 1.0
 anchor_bottom = 1.0
+mouse_filter = 2
 script = ExtResource( 1 )
 __meta__ = {
 "_edit_use_anchors_": false
 }
-continous_update = true
-consume_mouse_events = true
-disable_texture_filtering = false
 scroll_speed = 20.0
+continous_update = true
+disable_texture_filtering = false
 EguiTheme = "res://godot-editor.eguitheme"

--- a/example_project/GodotEguiExample.tscn
+++ b/example_project/GodotEguiExample.tscn
@@ -12,8 +12,8 @@ script = ExtResource( 2 )
 __meta__ = {
 "_edit_use_anchors_": false
 }
-handle_input = true
-handle_gui_input = false
+handle_input = false
+handle_gui_input = true
 
 [node name="GodotEgui" type="Control" parent="."]
 anchor_right = 1.0
@@ -24,6 +24,6 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 scroll_speed = 20.0
-continous_update = true
 disable_texture_filtering = false
-EguiTheme = "res://godot-editor.eguitheme"
+continous_update = true
+input_mode = 0

--- a/example_project/GodotEguiWindowExample.gdns
+++ b/example_project/GodotEguiWindowExample.gdns
@@ -1,0 +1,8 @@
+[gd_resource type="NativeScript" load_steps=2 format=2]
+
+[ext_resource path="res://godot_egui.gdnlib" type="GDNativeLibrary" id=1]
+
+[resource]
+resource_name = "GodotEguiWindowExample"
+class_name = "GodotEguiWindowExample"
+library = ExtResource( 1 )

--- a/example_project/GodotEguiWindowExample.tscn
+++ b/example_project/GodotEguiWindowExample.tscn
@@ -1,0 +1,18 @@
+[gd_scene load_steps=3 format=2]
+
+[ext_resource path="res://GodotEgui.gdns" type="Script" id=1]
+[ext_resource path="res://GodotEguiWindowExample.gdns" type="Script" id=2]
+
+[node name="GodotEguiWindowExample" type="Control"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+script = ExtResource( 2 )
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="GodotEgui" type="Control" parent="."]
+anchor_right = 1.0
+anchor_bottom = 1.0
+mouse_filter = 1
+script = ExtResource( 1 )

--- a/example_project/multi-demo-example.tscn
+++ b/example_project/multi-demo-example.tscn
@@ -1,0 +1,21 @@
+[gd_scene load_steps=3 format=2]
+
+[ext_resource path="res://GodotEguiExample.tscn" type="PackedScene" id=1]
+[ext_resource path="res://GodotEguiWindowExample.tscn" type="PackedScene" id=2]
+
+[node name="multi-demo-example" type="Node2D"]
+
+[node name="GodotEguiExample" parent="." instance=ExtResource( 1 )]
+margin_right = 1024.0
+margin_bottom = 600.0
+mouse_filter = 1
+
+[node name="GodotEguiWindowExample" parent="GodotEguiExample" instance=ExtResource( 2 )]
+margin_right = 1024.0
+margin_bottom = 600.0
+mouse_filter = 1
+
+[node name="GodotEguiWindowExample2" parent="GodotEguiExample/GodotEguiWindowExample" instance=ExtResource( 2 )]
+margin_right = 1024.0
+margin_bottom = 600.0
+mouse_filter = 1

--- a/example_project/src/lib.rs
+++ b/example_project/src/lib.rs
@@ -96,7 +96,8 @@ impl GodotEguiExample {
                 // Set the input as handled by the viewport if the gui believes that is has been captured.
                 unsafe { owner.get_viewport().expect("Viewport").assume_safe().set_input_as_handled() };
             }
-        }).expect("map_mut should succeed");
+        })
+        .expect("map_mut should succeed");
     }
 
     /// Updates egui from the `_gui_input` callback
@@ -109,7 +110,8 @@ impl GodotEguiExample {
             if gui.mouse_was_captured(instance) {
                 owner.accept_event();
             }
-        }).expect("map_mut should succeed");
+        })
+        .expect("map_mut should succeed");
     }
     #[export]
     #[gdnative::profiled]
@@ -117,7 +119,7 @@ impl GodotEguiExample {
         let gui = unsafe { self.gui.as_ref().expect("GUI initialized").assume_safe() };
 
         self.elapsed_time += delta;
-        
+
         // A frame can be passed to `update` specifying background color, margin and other properties
         // You may also want to pass in `None` and draw a background using a regular Panel node instead.
         let frame = egui::Frame { margin: egui::vec2(20.0, 20.0), ..Default::default() };
@@ -129,11 +131,10 @@ impl GodotEguiExample {
             if self.dynamically_change_pixels_per_point {
                 gui.set_pixels_per_point(instance, (self.elapsed_time.sin() * 0.20) + 0.8);
             }
-            
+
             // We use the `update` method here to just draw a simple UI on the central panel. If you need more
             // fine-grained control, you can use update_ctx to get access to egui's context directly.
             gui.update_ctx(instance, /* Some(frame), */ |ctx| {
-
                 egui::CentralPanel::default().frame(frame).show(ctx, |ui| {
                     ui.columns(2, |columns| {
                         let ui = &mut columns[0];

--- a/example_project/src/window.rs
+++ b/example_project/src/window.rs
@@ -1,0 +1,60 @@
+use gdnative::prelude::*;
+use godot_egui::*;
+
+#[derive(NativeClass)]
+#[inherit(Control)]
+pub struct GodotEguiWindowExample {
+    gui: Option<Instance<GodotEgui, Shared>>,
+}
+
+#[methods]
+impl GodotEguiWindowExample {
+    fn new(_: &Control) -> Self {
+        Self { gui: None }
+    }
+    #[export]
+    #[gdnative::profiled]
+    pub fn _ready(&mut self, owner: TRef<Control>) {
+        godot_print!("Initializing godot egui");
+        let gui = owner
+            .get_node("GodotEgui")
+            .and_then(|godot_egui| unsafe { godot_egui.assume_safe() }.cast::<Control>())
+            .and_then(|godot_egui| godot_egui.cast_instance::<GodotEgui>())
+            .expect("Expected a `GodotEgui` child with the GodotEgui nativescript class.");
+
+        self.gui = Some(gui.claim());
+    }
+
+    /// Updates egui from the `_gui_input` callback
+    #[export]
+    #[gdnative::profiled]
+    pub fn _gui_input(&mut self, owner: TRef<Control>, event: Ref<InputEvent>) {
+        let gui = unsafe { self.gui.as_ref().expect("GUI initialized").assume_safe() };
+        gui.map_mut(|gui, instance| {
+            gui.handle_godot_input(instance, event, true);
+            if gui.mouse_was_captured(instance) {
+                owner.accept_event();
+            }
+        })
+        .expect("map_mut should succeed");
+    }
+    #[export]
+    fn _process(&mut self, _owner: TRef<Control>, _: f64) {
+        if let Some(gui) = &self.gui {
+            let gui = unsafe { gui.assume_safe() };
+            gui.map_mut(|egui, o| {
+                egui.update_ctx(o, |ctx| {
+                    egui::Window::new("Test Window")
+                        .frame(egui::Frame::default())
+                        .min_height(100.0)
+                        .min_width(50.0)
+                        .resizable(true)
+                        .show(ctx, |ui| {
+                            ui.label("This is a window!");
+                        });
+                })
+            })
+            .expect("this should work");
+        }
+    }
+}

--- a/godot_egui/src/lib.rs
+++ b/godot_egui/src/lib.rs
@@ -118,6 +118,8 @@ impl GodotEgui {
             theme_path: "".to_owned(),
         }
     }
+
+    /// Set the pixels_per_point use by `egui` to render the screen. This should be used to scale the `egui` nodes if you are using a non-standard scale for nodes in your game.
     #[export]
     pub fn set_pixels_per_point(&mut self, _owner: TRef<Control>, pixels_per_point: f64) {
         if pixels_per_point > 0f64 {
@@ -167,13 +169,13 @@ impl GodotEgui {
             }
         }
     }
-    
+
     /// Is used to indicate if the mouse was captured during the previous frame.
     #[export]
     pub fn mouse_was_captured(&self, _owner: TRef<Control>) -> bool {
         self.mouse_was_captured
     }
-    /// Call from the user code to pass the input event into `Egui`. 
+    /// Call from the user code to pass the input event into `Egui`.
     /// `event` should be the raw `InputEvent` that is handled by `_input`, `_gui_input` and `_unhandled_input`.
     /// `is_gui_input` should be true only if this event should be processed like it was emitted from the `_gui_input` callback.
     #[export]
@@ -190,7 +192,8 @@ impl GodotEgui {
                 // NOTE: The egui is painted inside a control node, so its global rect offset must be taken into account.
                 let offset_position = mouse_pos - owner.get_global_rect().origin.to_vector();
                 // This is used to get the correct rotation when the root node is rotated.
-                owner.get_global_transform()
+                owner
+                    .get_global_transform()
                     .inverse()
                     .expect("screen space coordinates must be invertible")
                     .transform_vector(offset_position)


### PR DESCRIPTION
This PR closes #7 

A note about the changes. As you noted in #7 the correct place to put the input is `_gui_input` as that respects the input propagation and resolves the issue when multiple elements are overlapping with one another.

The one use-case this may break is anyone that expects two overlapping EGUI controls to both accept input will end up with broken behaviors between these UIs. This may break some expectations.

In addition, it appears that `_gui_input()` doesn't require matching the mouse position offset from the screen, it seems to get the correct coordinates, so I removed that code. (it still needs to be mapped to `egui::Vec2` though.

Please let me know if you have any questions.