### PR TITLE
Added reactive/continuous update

### DIFF
--- a/example_project/GodotEguiExample.tscn
+++ b/example_project/GodotEguiExample.tscn
@@ -23,6 +23,7 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 theme = ExtResource( 3 )
+scroll_speed = 20.0
+continous_update = true
 consume_mouse_events = true
 disable_texture_filtering = false
-scroll_speed = 20.0


### PR DESCRIPTION
After some digging, I was able to determine that egui is already using the `Reactive` style of gui update by default and indicates this via the `output.needs_repaint` flag. I added this change as well as a flag for `continous_update` which will call the `Context::request_repaint` method every frame as well as a `refresh` method that can be used to force a repaint when the data model changes.

The benefit of this change is that we can reduce the number of draw calls and painting required for an update. In addition, users can have more control over when egui draws. This is particularly useful for any HUDs where the data rarely changes with minimal animation.

Here's some background on each change.

Wrapping the tessellation and painting is the analog to how it works with the egui demo for native and web apps. Since output will indicate whether EGUI thinks that it needs to update.

`continous_update` flag: As discussed on discord, having the flag is a good way of exposing the API to users so that they can just be concerned with making their UI and not worrying about whether they should call the context or not from within EGUI. Advanced users can do so, but having a simple check is good for compatibility across plugins.

`refresh()` method: This method is only available to force an update when the backend data changes. Some widgets will track their state and call `request_repaint` but most widgets do not. In addition, most egui widgets don't retain any state information, so it's necessary that the user notify that the data has changed and everything requires a repaint.

Please let me know if you have any other changes regarding the API such as naming conventions  that you would like to take a look at.