### PR TITLE
Added the ability to configure pixels_per_point to allow for egui to properly scale the UI

### DIFF
--- a/example_project/GodotEguiExample.tscn
+++ b/example_project/GodotEguiExample.tscn
@@ -20,7 +20,7 @@ script = ExtResource( 1 )
 __meta__ = {
 "_edit_use_anchors_": false
 }
-scroll_speed = 20.0
-disable_texture_filtering = false
+disable_texture_filtering = true
 consume_mouse_events = true
+scroll_speed = 20.0
 EguiTheme = "res://godot-editor.eguitheme"


### PR DESCRIPTION
This should fix the issue with pixels per point not properly being set by the UI. This allows the individual control nodes to properly scale egui as needed.

Also made some minor changes to the function call of paint_shapes, since it is already using &mut self, rather than passing the texture into the method, the method queries for it directly.

Also added some additional widgets to the example to test the mouse position is correct regardless of the pixels_per_point setting.

Let me know if you have any questions about the changes.