### PR TITLE
Added egui mouse cursors to `GodotEgui` 

### DIFF
--- a/godot_egui/src/enum_conversions.rs
+++ b/godot_egui/src/enum_conversions.rs
@@ -1,4 +1,5 @@
 use gdnative::api::GlobalConstants;
+use gdnative::api::control::CursorShape;
 
 pub fn scancode_to_egui(scancode: i64) -> Option<egui::Key> {
     match scancode {
@@ -63,5 +64,36 @@ pub fn mouse_button_index_to_egui(button_index: i64) -> Option<egui::PointerButt
         GlobalConstants::BUTTON_RIGHT => Some(egui::PointerButton::Secondary),
         GlobalConstants::BUTTON_MIDDLE => Some(egui::PointerButton::Middle),
         _ => None,
+    }
+}
+
+/// Converts the `egui::CursorIcon` to a Godot `Control::CursorShape`
+pub fn mouse_cursor_egui_to_godot(cursor: egui::CursorIcon) -> CursorShape {
+    use egui::CursorIcon;
+    // Any missing egui::CursorIcon enum options use the default case if there is currently not
+    // an equivalent in Godot. 
+    match cursor {
+        CursorIcon::Default => CursorShape::ARROW,
+        CursorIcon::ContextMenu => CursorShape::ARROW,
+        CursorIcon::Help => CursorShape::HELP,
+        CursorIcon::PointingHand => CursorShape::POINTING_HAND,
+        CursorIcon::Progress => CursorShape::BUSY,
+        CursorIcon::Wait => CursorShape::WAIT,
+        CursorIcon::Cell => CursorShape::CROSS,
+        CursorIcon::Crosshair => CursorShape::CROSS,
+        CursorIcon::Text => CursorShape::IBEAM,
+        CursorIcon::VerticalText => CursorShape::IBEAM,
+        CursorIcon::Move => CursorShape::MOVE,
+        CursorIcon::NoDrop => CursorShape::FORBIDDEN,
+        CursorIcon::NotAllowed => CursorShape::FORBIDDEN,
+        CursorIcon::Grab => CursorShape::DRAG,
+        CursorIcon::Grabbing => CursorShape::DRAG,
+        CursorIcon::AllScroll => CursorShape::MOVE,
+        CursorIcon::ResizeHorizontal => CursorShape::HSIZE,
+        CursorIcon::ResizeNeSw => CursorShape::BDIAGSIZE,
+        CursorIcon::ResizeNwSe => CursorShape::FDIAGSIZE,
+        CursorIcon::ResizeVertical => CursorShape::VSIZE,
+        // The default case in Godot Engine is arrow.
+        _ => CursorShape::ARROW,
     }
 }

--- a/godot_egui/src/lib.rs
+++ b/godot_egui/src/lib.rs
@@ -60,6 +60,7 @@ pub struct GodotEgui {
     main_texture: SyncedTexture,
     raw_input: Rc<RefCell<egui::RawInput>>,
     mouse_was_captured: bool,
+    cursor_icon: egui::CursorIcon,
 
     /// This flag will force a UI to redraw every frame.
     /// This can be used for when the UI's backend events are always changing.
@@ -113,6 +114,7 @@ impl GodotEgui {
             },
             raw_input: Rc::new(RefCell::new(egui::RawInput::default())),
             mouse_was_captured: false,
+            cursor_icon: egui::CursorIcon::Default,
             continous_update: false,
             scroll_speed: 20.0,
             consume_mouse_events: true,
@@ -385,6 +387,11 @@ impl GodotEgui {
         // shouldn't be an issue.
         self.mouse_was_captured = self.egui_ctx.is_using_pointer();
 
+        // When we have a new cursor, we need to update the Godot side.
+        if self.cursor_icon != output.cursor_icon {
+            self.cursor_icon = output.cursor_icon;
+            owner.set_default_cursor_shape(enum_conversions::mouse_cursor_egui_to_godot(self.cursor_icon).0);
+        }
         // `egui_ctx` will use all the layout code to determine if there are any changes.
         // `output.needs_repaint` lets `GodotEgui` know whether we need to redraw the clipped mesh and repaint the new texture or not.
         if output.needs_repaint {


### PR DESCRIPTION
The change in behavior can be seen in  `GodotEguiExample.tscn` depending upon the widget thjat is hovered. Previously only the arrow pointer would be used, now we can get a wider range of pointers.

This change plumbs egui::CursorIcon from the output and creates a conversion method to the Godot `Control::CursorShape` type for use in the engine by changing the `GodotEgui` nodes default cursor whenever the egui output changes.
This closes issue #17 