### PR TITLE
pixels_per_point now adjusts egui::RawInput::screen_rect parameters

### DIFF
--- a/godot_egui/src/lib.rs
+++ b/godot_egui/src/lib.rs
@@ -363,9 +363,11 @@ impl GodotEgui {
     pub fn update_ctx(&mut self, owner: TRef<Control>, draw_fn: impl FnOnce(&mut egui::CtxRef)) {
         // Collect input
         let mut raw_input = self.raw_input.take();
+        // Ensure that the egui context fills the entire space of the node and is adjusted accordinglly.
         let size = owner.get_rect().size;
+        let points_per_pixel = (1.0 / self.pixels_per_point) as f32;
         raw_input.screen_rect =
-            Some(egui::Rect::from_min_size(Default::default(), egui::Vec2::new(size.width, size.height)));
+            Some(egui::Rect::from_min_size(Default::default(), egui::Vec2::new(size.width * points_per_pixel, size.height * points_per_pixel)));
 
         self.egui_ctx.begin_frame(raw_input);
 


### PR DESCRIPTION
Changes the behavior of the pixels_per_point to also modify the screen rect to ensure that the screen rect filled by egui is identical to the full `GodotEgui` node.

This changes the current behavior from scaling the text to a percentage of the screen space to still filling the entire screen.

There are a couple of points I would like to confirm:
- Do we need to make any additional changes to the behavior of the egui::RawInput::screen_rect setting?
- Is the assumption with `GodotEgui` that egui should always fill the entire rect used by the node?