### PR TITLE
Ensure fonts are loaded after _ready by triggering an empty update.

### DIFF
--- a/godot_egui/src/lib.rs
+++ b/godot_egui/src/lib.rs
@@ -243,6 +243,11 @@ impl GodotEgui {
                 godot_error!("file {} does not exist", &self.theme_path)
             }
         }
+
+        // Force an update after loading the theme. This ensures the font texture is built and that the inner
+        // EguiCtx is not left in an intermediate state.
+        self.egui_ctx.begin_frame(egui::RawInput::default());
+        let _ = self.egui_ctx.end_frame();
     }
 
     /// Is used to indicate if the mouse was captured during the previous frame.


### PR DESCRIPTION
Egui only builds fonts at the start of the next frame, so if the theme is loaded on `_ready`, the font texture won't be updated until the first `GodotEgui::update`, which means that a GUI that draws their first frame after some time (e.g. when a menu is first shown) will cause a noticeable hiccup.

This would also cause issues if you want to add some extra fonts after loading a theme. After calling `_ready` on a GodotEgui object, trying to access `egui.fonts().definitions()` would return the old value, not the one set by the theme.

Triggering an empty update takes care of the problem with no noticeable side effects.