### PR TITLE
Update godot-rust and egui

### DIFF
--- a/example_project/Cargo.toml
+++ b/example_project/Cargo.toml
@@ -10,7 +10,7 @@ workspace = ".."
 crate-type = ["cdylib"]
 
 [dependencies]
-#gdnative = { git = "https://github.com/godot-rust/godot-rust.git", branch = "master" }
-gdnative = "0.10.0-rc.0"
+gdnative = { git = "https://github.com/godot-rust/godot-rust.git", branch = "master" }
+#gdnative = "0.10"
 egui = "0.15"
 godot_egui = { path = "../godot_egui" }

--- a/example_project/Cargo.toml
+++ b/example_project/Cargo.toml
@@ -12,5 +12,5 @@ crate-type = ["cdylib"]
 [dependencies]
 gdnative = { git = "https://github.com/godot-rust/godot-rust.git", branch = "master" }
 #gdnative = "0.10"
-egui = "0.15"
+egui = "0.18.1"
 godot_egui = { path = "../godot_egui" }

--- a/example_project/Cargo.toml
+++ b/example_project/Cargo.toml
@@ -11,6 +11,5 @@ crate-type = ["cdylib"]
 
 [dependencies]
 gdnative = { git = "https://github.com/godot-rust/godot-rust.git", branch = "master" }
-#gdnative = "0.10"
-egui = "0.18.1"
+egui = "0.18"
 godot_egui = { path = "../godot_egui" }

--- a/example_project/src/lib.rs
+++ b/example_project/src/lib.rs
@@ -66,7 +66,7 @@ impl GodotEguiExample {
 
         // A frame can be passed to `update` specifying background color, margin and other properties
         // You may also want to pass in `None` and draw a background using a regular Panel node instead.
-        let frame = egui::Frame { margin: egui::vec2(20.0, 20.0), ..Default::default() };
+        let frame = egui::Frame { inner_margin: egui::style::Margin::symmetric(20.0, 20.0), ..Default::default() };
 
         let mut should_reverse_font_priorities = false;
 
@@ -102,12 +102,12 @@ impl GodotEguiExample {
 
                         ui.heading("You can even plot graphs");
                         ui.add_space(5.0);
-
-                        let plot = egui::plot::Plot::new("plot_example")
-                            .line(self.sin_plot())
+                        
+                        egui::plot::Plot::new("plot_example")
                             .width(400.0)
-                            .view_aspect(4.0 / 3.0);
-                        ui.add(plot);
+                            .view_aspect(4.0 / 3.0)
+                            .show(ui, |ui| ui.line(self.sin_plot()));
+                        // ui.add(plot);
 
                         ui.heading("Or use your custom images");
                         ui.add_space(5.0);
@@ -162,25 +162,26 @@ impl GodotEguiExample {
                         });
                     });
                 });
-
+                // TODO: How fonts are stored has completely changed so this will need to be redone.
                 if self.show_font_settings {
-                    let mut font_definitions = ctx.fonts().definitions().clone();
-                    egui::Window::new("Settings").open(&mut self.show_font_settings).show(ctx, |ui| {
-                        use egui::Widget;
-                        font_definitions.ui(ui);
-                        ui.fonts().texture().ui(ui);
+                //     let mut font_definitions = ctx.fonts().definitions().clone();
+                    egui::Window::new("Settings").open(&mut self.show_font_settings).show(ctx, |_ui| {
+                //         use egui::Widget;
+                //         font_definitions.ui(ui);
+                //         ui.fonts().texture().ui(ui);
                     });
-                    ctx.set_fonts(font_definitions);
+                //     ctx.set_fonts(font_definitions);
                 }
             });
 
-            if should_reverse_font_priorities {
-                gui.update_ctx(&instance, |ctx| {
-                    let mut font_defs = ctx.fonts().definitions().clone();
-                    font_defs.fonts_for_family.get_mut(&egui::FontFamily::Proportional).unwrap().reverse();
-                    ctx.set_fonts(font_defs);
-                })
-            }
+            // TODO: How fonts are stored has completely changed so this will need to be redone.
+            // if should_reverse_font_priorities {
+            //     gui.update_ctx(&instance, |ctx| {
+            //         let mut font_defs = ctx.fonts().definitions().clone();
+            //         font_defs.fonts_for_family.get_mut(&egui::FontFamily::Proportional).unwrap().reverse();
+            //         ctx.set_fonts(font_defs);
+            //     })
+            // }
         })
         .expect("Map mut should succeed");
     }

--- a/example_project/src/lib.rs
+++ b/example_project/src/lib.rs
@@ -15,7 +15,6 @@ pub struct GodotEguiExample {
     checkbox: bool,
     icon_1: Ref<Texture>,
     icon_2: Ref<Texture>,
-    use_custom_fonts: bool,
     show_font_settings: bool,
 }
 
@@ -29,7 +28,6 @@ impl GodotEguiExample {
             elapsed_time: 0.0,
             icon_1: load_texture("res://icon.png"),
             icon_2: load_texture("res://icon_ferris.png"),
-            use_custom_fonts: false,
             show_font_settings: false,
         }
     }
@@ -67,8 +65,6 @@ impl GodotEguiExample {
         // A frame can be passed to `update` specifying background color, margin and other properties
         // You may also want to pass in `None` and draw a background using a regular Panel node instead.
         let frame = egui::Frame { inner_margin: egui::style::Margin::symmetric(20.0, 20.0), ..Default::default() };
-
-        let mut should_reverse_font_priorities = false;
 
         gui.map_mut(|gui, instance| {
             // We use the `update` method here to just draw a simple UI on the central panel. If you need more
@@ -132,15 +128,8 @@ impl GodotEguiExample {
                         ui.label(
                             "This example registers two custom fonts. Custom fonts can be registered from the \
                              Godot Editor by setting font paths. For more control, you can also use \
-                             egui::Context's set_fonts method to register fonts manually.
-                         \nEgui does not currently support locally overriding a font, but you can switch the \
-                             global font priorities for an egui::Context so that different fonts take \
-                             precedence. The checkbox below will reverse the vector of fonts so that the last \
-                             one, our Custom Font 2, becomes the main font.",
+                             egui::Context's set_fonts method to register fonts manually.",
                         );
-                        if ui.checkbox(&mut self.use_custom_fonts, "Reverse font priorities").clicked() {
-                            should_reverse_font_priorities = true;
-                        }
 
                         ui.add_space(5.0);
 
@@ -155,33 +144,20 @@ impl GodotEguiExample {
                         ui.add_space(5.0);
 
                         ui.horizontal(|ui| {
-                            ui.label("You can also configure font settings, check it out:");
+                            ui.label("You can also configure style settings, check it out:");
                             if ui.button("Font settings").clicked() {
                                 self.show_font_settings = true;
                             }
                         });
                     });
                 });
-                // TODO: How fonts are stored has completely changed so this will need to be redone.
+                // TODO: How fonts are stored has completely changed so this will need to be redone if it is desired in the sample project.
                 if self.show_font_settings {
-                //     let mut font_definitions = ctx.fonts().definitions().clone();
-                    egui::Window::new("Settings").open(&mut self.show_font_settings).show(ctx, |_ui| {
-                //         use egui::Widget;
-                //         font_definitions.ui(ui);
-                //         ui.fonts().texture().ui(ui);
+                    egui::Window::new("Style Settings").open(&mut self.show_font_settings).show(ctx, |ui| {
+                        ctx.style_ui(ui)
                     });
-                //     ctx.set_fonts(font_definitions);
                 }
             });
-
-            // TODO: How fonts are stored has completely changed so this will need to be redone.
-            // if should_reverse_font_priorities {
-            //     gui.update_ctx(&instance, |ctx| {
-            //         let mut font_defs = ctx.fonts().definitions().clone();
-            //         font_defs.fonts_for_family.get_mut(&egui::FontFamily::Proportional).unwrap().reverse();
-            //         ctx.set_fonts(font_defs);
-            //     })
-            // }
         })
         .expect("Map mut should succeed");
     }

--- a/example_project/src/lib.rs
+++ b/example_project/src/lib.rs
@@ -34,8 +34,8 @@ impl GodotEguiExample {
         }
     }
 
-    #[export]
-    pub fn _ready(&mut self, owner: TRef<Control>) {
+    #[godot]
+    pub fn _ready(&mut self, #[base] owner: TRef<Control>) {
         godot_print!("Initializing godot egui");
         let gui = owner
             .get_node("GodotEgui")
@@ -58,8 +58,8 @@ impl GodotEguiExample {
         .name("wave")
     }
 
-    #[export]
-    pub fn _process(&mut self, _owner: TRef<Control>, delta: f64) {
+    #[godot]
+    pub fn _process(&mut self, delta: f64) {
         let gui = unsafe { self.gui.as_ref().expect("GUI initialized").assume_safe() };
 
         self.elapsed_time += delta;

--- a/example_project/src/lib.rs
+++ b/example_project/src/lib.rs
@@ -132,11 +132,11 @@ impl GodotEguiExample {
                         ui.label(
                             "This example registers two custom fonts. Custom fonts can be registered from the \
                              Godot Editor by setting font paths. For more control, you can also use \
-                             egui::CtxRef's set_fonts method to register fonts manually.
+                             egui::Context's set_fonts method to register fonts manually.
                          \nEgui does not currently support locally overriding a font, but you can switch the \
-                             global font priorities for an egui::CtxRef so that different fonts take precedence. \
-                             The checkbox below will reverse the vector of fonts so that the last one, our \
-                             Custom Font 2, becomes the main font.",
+                             global font priorities for an egui::Context so that different fonts take \
+                             precedence. The checkbox below will reverse the vector of fonts so that the last \
+                             one, our Custom Font 2, becomes the main font.",
                         );
                         if ui.checkbox(&mut self.use_custom_fonts, "Reverse font priorities").clicked() {
                             should_reverse_font_priorities = true;

--- a/godot_egui/Cargo.toml
+++ b/godot_egui/Cargo.toml
@@ -14,4 +14,4 @@ workspace = ".."
 [dependencies]
 gdnative = { git = "https://github.com/godot-rust/godot-rust.git", branch = "master"}
 #gdnative = "0.10"
-egui = "0.15"
+egui = "0.18.1"

--- a/godot_egui/Cargo.toml
+++ b/godot_egui/Cargo.toml
@@ -12,6 +12,6 @@ readme = "../README.md"
 workspace = ".."
 
 [dependencies]
-#gdnative = { git = "https://github.com/godot-rust/godot-rust.git", branch = "master"}
-gdnative = "0.10.0-rc.0"
+gdnative = { git = "https://github.com/godot-rust/godot-rust.git", branch = "master"}
+#gdnative = "0.10"
 egui = "0.15"

--- a/godot_egui/Cargo.toml
+++ b/godot_egui/Cargo.toml
@@ -13,5 +13,4 @@ workspace = ".."
 
 [dependencies]
 gdnative = { git = "https://github.com/godot-rust/godot-rust.git", branch = "master"}
-#gdnative = "0.10"
-egui = "0.18.1"
+egui = "0.18"

--- a/godot_egui/src/egui_helpers.rs
+++ b/godot_egui/src/egui_helpers.rs
@@ -17,7 +17,7 @@ pub fn progress_bar(ui: &mut egui::Ui, progress: f32) -> egui::Response {
         rect.center(),
         egui::Align2::CENTER_CENTER,
         format!("{:.2}", progress),
-        egui::TextStyle::Body,
+        egui::FontId::proportional(24.0), // TODO(bromeon): which size?
         ui.style().visuals.text_color(),
     );
 

--- a/godot_egui/src/egui_helpers.rs
+++ b/godot_egui/src/egui_helpers.rs
@@ -1,4 +1,4 @@
-pub fn progress_bar(ui: &mut egui::Ui, progress: f32) -> egui::Response {
+pub fn progress_bar(ui: &mut egui::Ui, progress: f32, font_size: f32) -> egui::Response {
     let desired_size = ui.spacing().interact_size.y * egui::vec2(8.0, 0.8);
     let (rect, response) = ui.allocate_exact_size(desired_size, egui::Sense::hover());
 
@@ -17,7 +17,7 @@ pub fn progress_bar(ui: &mut egui::Ui, progress: f32) -> egui::Response {
         rect.center(),
         egui::Align2::CENTER_CENTER,
         format!("{:.2}", progress),
-        egui::FontId::proportional(24.0), // TODO(bromeon): which size?
+        egui::FontId::proportional(font_size),
         ui.style().visuals.text_color(),
     );
 

--- a/godot_egui/src/lib.rs
+++ b/godot_egui/src/lib.rs
@@ -267,11 +267,18 @@ impl GodotEgui {
             }
         };
         let pixels = if let Some(pos) = texture_pos {
-            let insertion_start = pos[0] as i32 * pos[1] as i32;
+            assert_eq!(delta.image.width() * delta.image.height() * 4, pixel_delta.len() as usize, "delta is not compatible with the pixels");
+            // let insertion_start = pos[0] * pos[1];
             let image = texture.get_data().expect("this must exist");
+            
             let mut data = unsafe { image.assume_safe().get_data() };
-            for idx in 0 .. pixel_delta.len() {
-                data.set(insertion_start, pixel_delta.get(idx));
+            // width is multiplied by 4 as a magic number due as these are bytes.
+
+            for x in pos[0]..delta.image.width() * 4 {
+                for y in pos[1]..delta.image.height() {
+                    let idx = x * y;
+                    data.set(idx as i32, pixel_delta.get(idx as i32));
+                }
             }
             data
         } else {

--- a/godot_egui/src/lib.rs
+++ b/godot_egui/src/lib.rs
@@ -98,6 +98,7 @@ impl GodotEgui {
             raw_input: Rc::new(RefCell::new(egui::RawInput::default())),
             mouse_was_captured: false,
             override_default_fonts: false,
+            // reverse_font_priority: false,
             custom_fonts: [None, None, None, None, None],
             scroll_speed: 20.0,
             consume_mouse_events: true,
@@ -114,8 +115,7 @@ impl GodotEgui {
         let _ = self.egui_ctx.end_frame();
 
         // This is where "res://" points to
-        //let mut font_defs = self.egui_ctx.fonts().definitions().clone();
-        let mut font_defs = FontDefinitions::default(); // TODO(bromeon): changed from egui 0.15->0.18; correct?
+        let mut font_defs = FontDefinitions::default();
 
         if self.override_default_fonts {
             font_defs.families.get_mut(&egui::FontFamily::Proportional).unwrap().clear()


### PR DESCRIPTION
**godot-rust**
Updates to `master` version. Implements new API from https://github.com/godot-rust/godot-rust/pull/872.
This API is still in flux despite merged, so we could also skip that commit and wait until an API lands in a released version.

**egui**
I tried updating egui 0.15 to egui 0.18. For the most part, this worked, however:
* For the texture-related functionality, I wasn't the one who wrote the original code, and the egui API is wildly different now. Might be good if someone else who knows more about those parts could complete this PR.
* I left two `TODO(bromeon)` in the code for places where I wasn't sure, would appreciate a review/correction.

This PR allows edits by maintainers, feel free to push other commits on top.