### PR TITLE
Update to gdnative 0.10.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,13 +66,13 @@ In order to handle input, `GodotEgui` exposes the `handle_godot_input` and `mous
 To handle input from `_input` or `_unhandled_input` use the following:
 
 ```rust
-#[export]
+#[method]
 // fn _unhandled_input(&mut self, owner: TRef<Control>, event: Ref<InputEvent>) also works.
-fn _input(&mut self, owner: TRef<Control>, event: Ref<InputEvent>) {
+fn _input(&mut self, #[base] owner: TRef<Control>, event: Ref<InputEvent>) {
     let gui = unsafe { self.gui.as_ref().expect("GUI initialized").assume_safe() };
     gui.map_mut(|gui, instance| {
         gui.handle_godot_input(instance, event, false);
-        if gui.mouse_was_captured(instance) {
+        if gui.mouse_was_captured() {
             // Set the input as handled by the viewport if the gui believes that is has been captured.
             unsafe { owner.get_viewport().expect("Viewport").assume_safe().set_input_as_handled() };
         }
@@ -84,12 +84,12 @@ fn _input(&mut self, owner: TRef<Control>, event: Ref<InputEvent>) {
 To handle input from `_gui_input` use the following:
 
 ```rust
-#[export]
-fn _gui_input(&mut self, owner: TRef<Control>, event: Ref<InputEvent>) {
+#[method]
+fn _gui_input(&mut self, #[base] owner: TRef<Control>, event: Ref<InputEvent>) {
     let gui = unsafe { self.gui.as_ref().expect("GUI initialized").assume_safe() };
     gui.map_mut(|gui, instance| {
         gui.handle_godot_input(instance, event, true);
-        if gui.mouse_was_captured(instance) {
+        if gui.mouse_was_captured() {
             // `_gui_input` uses accept_event() to stop the propagation of events.
             owner.accept_event();
         }

--- a/egui_stylist_addon/Cargo.toml
+++ b/egui_stylist_addon/Cargo.toml
@@ -10,7 +10,8 @@ workspace = ".."
 crate-type = ["cdylib"]
 
 [dependencies]
-gdnative = "0.10"
+#gdnative = "0.10"
+gdnative = { git = "https://github.com/godot-rust/godot-rust.git", branch = "master" }
 egui = "0.18"
 godot_egui = { path = "../godot_egui", features = ["theme_support"] }
 egui-theme = "0.2.0"

--- a/egui_stylist_addon/Cargo.toml
+++ b/egui_stylist_addon/Cargo.toml
@@ -10,8 +10,8 @@ workspace = ".."
 crate-type = ["cdylib"]
 
 [dependencies]
-#gdnative = "0.10"
-gdnative = { git = "https://github.com/godot-rust/godot-rust.git", branch = "master" }
+gdnative = "0.10.1"
+#gdnative = { git = "https://github.com/godot-rust/godot-rust.git", branch = "master" }
 egui = "0.18"
 godot_egui = { path = "../godot_egui", features = ["theme_support"] }
 egui-theme = "0.2.0"

--- a/egui_stylist_addon/src/stylist.rs
+++ b/egui_stylist_addon/src/stylist.rs
@@ -18,20 +18,20 @@ impl GodotEguiStylist {
     }
 
     /// Updates egui from the `_gui_input` callback
-    #[export]
-    pub fn _gui_input(&mut self, owner: TRef<Control>, event: Ref<InputEvent>) {
+    #[method]
+    pub fn _gui_input(&mut self, #[base] owner: TRef<Control>, event: Ref<InputEvent>) {
         let gui = unsafe { self.godot_egui.as_ref().expect("GUI initialized").assume_safe() };
         gui.map_mut(|gui, instance| {
             gui.handle_godot_input(instance, event, true);
-            if gui.mouse_was_captured(instance) {
+            if gui.mouse_was_captured() {
                 owner.accept_event();
             }
         })
         .expect("map_mut should succeed");
     }
 
-    #[export]
-    fn _ready(&mut self, owner: TRef<Control>) {
+    #[method]
+    fn _ready(&mut self, #[base] owner: TRef<Control>) {
         let gui = owner
             .get_node("godot_egui")
             .and_then(|godot_egui| unsafe { godot_egui.assume_safe() }.cast::<Control>())
@@ -64,8 +64,8 @@ impl GodotEguiStylist {
         self.godot_egui = Some(gui.claim());
         self.file_dialog = Some(file_dialog.claim());
     }
-    #[export]
-    fn _process(&mut self, owner: TRef<Control>, _: f32) {
+    #[method]
+    fn _process(&mut self, #[base] owner: TRef<Control>, _: f32) {
         let egui = unsafe { self.godot_egui.as_ref().expect("this must be initialized").assume_safe() };
         egui.map_mut(|gui, gui_owner| {
             gui.update_ctx(gui_owner.as_ref(), |ctx| {
@@ -75,8 +75,8 @@ impl GodotEguiStylist {
         })
         .expect("this should work");
     }
-    #[export]
-    fn on_file_dialog_closed(&mut self, _: &Control) {
+    #[method]
+    fn on_file_dialog_closed(&mut self) {
         godot_print!("on_file_dialog_closed");
         // owner.set_process(true);
         unsafe { self.godot_egui.as_ref().expect("should be initialized").assume_safe() }
@@ -86,8 +86,8 @@ impl GodotEguiStylist {
             })
             .expect("this should work");
     }
-    #[export]
-    fn on_file_selected(&mut self, _: TRef<Control>, path: GodotString) {
+    #[method]
+    fn on_file_selected(&mut self, path: GodotString) {
         godot_print!("on_file_selected");
         // Do the saving or loading
         let fd = unsafe { self.file_dialog.expect("file dialog should be initialized").assume_safe() };

--- a/example_project/Cargo.toml
+++ b/example_project/Cargo.toml
@@ -10,8 +10,8 @@ workspace = ".."
 crate-type = ["cdylib"]
 
 [dependencies]
-gdnative = { git = "https://github.com/godot-rust/godot-rust.git", branch = "master" }
-#gdnative = "0.10"
+gdnative = "0.10.1"
+#gdnative = { git = "https://github.com/godot-rust/godot-rust.git", branch = "master" }
 egui = "0.18"
 egui_demo_lib = "0.18"
 godot_egui = { path = "../godot_egui" }

--- a/example_project/Cargo.toml
+++ b/example_project/Cargo.toml
@@ -10,7 +10,8 @@ workspace = ".."
 crate-type = ["cdylib"]
 
 [dependencies]
-gdnative = "0.10"
+gdnative = { git = "https://github.com/godot-rust/godot-rust.git", branch = "master" }
+#gdnative = "0.10"
 egui = "0.18"
 egui_demo_lib = "0.18"
 godot_egui = { path = "../godot_egui" }

--- a/example_project/src/color_test.rs
+++ b/example_project/src/color_test.rs
@@ -16,8 +16,8 @@ impl GodotEguiColorTest {
         Self { egui_test: egui_demo_lib::ColorTest::default(), gui: None }
     }
 
-    #[export]
-    fn _ready(&mut self, owner: TRef<Control>) {
+    #[method]
+    fn _ready(&mut self, #[base] owner: TRef<Control>) {
         godot_print!("Test node ready");
         let gui = owner
             .get_node("GodotEgui")
@@ -28,8 +28,8 @@ impl GodotEguiColorTest {
         self.gui = Some(gui.claim());
     }
 
-    #[export]
-    fn _process(&mut self, _owner: &Control, _delta: f64) {
+    #[method]
+    fn _process(&mut self, _delta: f64) {
         let gui = unsafe { self.gui.as_ref().expect("GUI initialized").assume_safe() };
         gui.map_mut(|gui, instance| {
             gui.update_ctx(instance.as_ref(), |ctx| self.draw(ctx));

--- a/example_project/src/egui_demo.rs
+++ b/example_project/src/egui_demo.rs
@@ -14,8 +14,8 @@ impl GodotEguiDemoLib {
         Self { egui_demo: egui_demo_lib::DemoWindows::default(), gui: None }
     }
 
-    #[export]
-    fn _ready(&mut self, owner: TRef<Control>) {
+    #[method]
+    fn _ready(&mut self, #[base] owner: TRef<Control>) {
         godot_print!("Test node ready");
         let gui = owner
             .get_node("GodotEgui")
@@ -26,8 +26,8 @@ impl GodotEguiDemoLib {
         self.gui = Some(gui.claim());
     }
 
-    #[export]
-    fn _process(&mut self, _owner: &Control, _delta: f64) {
+    #[method]
+    fn _process(&mut self, _delta: f64) {
         let gui = unsafe { self.gui.as_ref().expect("GUI initialized").assume_safe() };
         gui.map_mut(|gui, instance| {
             gui.update_ctx(instance.as_ref(), |ctx| self.egui_demo.ui(ctx));

--- a/example_project/src/lib.rs
+++ b/example_project/src/lib.rs
@@ -55,8 +55,8 @@ impl GodotEguiExample {
         }
     }
 
-    #[export]
-    pub fn _ready(&mut self, owner: TRef<Control>) {
+    #[method]
+    pub fn _ready(&mut self, #[base] owner: TRef<Control>) {
         godot_print!("Initializing godot egui");
         owner.set_process_input(self.handle_input);
         if self.handle_gui_input {
@@ -89,12 +89,12 @@ impl GodotEguiExample {
         .name("wave")
     }
     /// Updates egui from the `_input` callback
-    #[export]
-    pub fn _input(&mut self, owner: TRef<Control>, event: Ref<InputEvent>) {
+    #[method]
+    pub fn _input(&mut self, #[base] owner: TRef<Control>, event: Ref<InputEvent>) {
         let gui = unsafe { self.gui.as_ref().expect("GUI initialized").assume_safe() };
         gui.map_mut(|gui, instance| {
             gui.handle_godot_input(instance, event, false);
-            if gui.mouse_was_captured(instance) {
+            if gui.mouse_was_captured() {
                 // Set the input as handled by the viewport if the gui believes that is has been captured.
                 unsafe { owner.get_viewport().expect("Viewport").assume_safe().set_input_as_handled() };
             }
@@ -103,19 +103,19 @@ impl GodotEguiExample {
     }
 
     /// Updates egui from the `_gui_input` callback
-    #[export]
-    pub fn _gui_input(&mut self, owner: TRef<Control>, event: Ref<InputEvent>) {
+    #[method]
+    pub fn _gui_input(&mut self, #[base] owner: TRef<Control>, event: Ref<InputEvent>) {
         let gui = unsafe { self.gui.as_ref().expect("GUI initialized").assume_safe() };
         gui.map_mut(|gui, instance| {
             gui.handle_godot_input(instance, event, true);
-            if gui.mouse_was_captured(instance) {
+            if gui.mouse_was_captured() {
                 owner.accept_event();
             }
         })
         .expect("map_mut should succeed");
     }
-    #[export]
-    pub fn _process(&mut self, _owner: TRef<Control>, delta: f64) {
+    #[method]
+    pub fn _process(&mut self, delta: f64) {
         let gui = unsafe { self.gui.as_ref().expect("GUI initialized").assume_safe() };
 
         self.elapsed_time += delta;
@@ -127,7 +127,7 @@ impl GodotEguiExample {
         gui.map_mut(|gui, instance| {
             // This resizes the window each frame based on a sine wave
             if self.dynamically_change_pixels_per_point {
-                gui.set_pixels_per_point(instance, (self.elapsed_time.sin() * 0.20) + 0.8);
+                gui.set_pixels_per_point((self.elapsed_time.sin() * 0.20) + 0.8);
             }
 
             // We use the `update` method here to just draw a simple UI on the central panel. If you need more

--- a/example_project/src/window.rs
+++ b/example_project/src/window.rs
@@ -12,9 +12,9 @@ impl GodotEguiWindowExample {
     fn new(_: &Control) -> Self {
         Self { gui: None }
     }
-    #[export]
+    #[method]
     #[profiled]
-    pub fn _ready(&mut self, owner: TRef<Control>) {
+    pub fn _ready(&mut self, #[base] owner: TRef<Control>) {
         godot_print!("Initializing godot egui");
         let gui = owner
             .get_node("GodotEgui")
@@ -26,20 +26,20 @@ impl GodotEguiWindowExample {
     }
 
     /// Updates egui from the `_gui_input` callback
-    #[export]
+    #[method]
     #[profiled]
-    pub fn _gui_input(&mut self, owner: TRef<Control>, event: Ref<InputEvent>) {
+    pub fn _gui_input(&mut self, #[base] owner: TRef<Control>, event: Ref<InputEvent>) {
         let gui = unsafe { self.gui.as_ref().expect("GUI initialized").assume_safe() };
         gui.map_mut(|gui, instance| {
             gui.handle_godot_input(instance, event, true);
-            if gui.mouse_was_captured(instance) {
+            if gui.mouse_was_captured() {
                 owner.accept_event();
             }
         })
         .expect("map_mut should succeed");
     }
-    #[export]
-    fn _process(&mut self, _owner: TRef<Control>, _: f64) {
+    #[method]
+    fn _process(&mut self, _: f64) {
         if let Some(gui) = &self.gui {
             let gui = unsafe { gui.assume_safe() };
             gui.map_mut(|egui, o| {

--- a/godot_egui/Cargo.toml
+++ b/godot_egui/Cargo.toml
@@ -12,7 +12,8 @@ readme = "../README.md"
 workspace = ".."
 
 [dependencies]
-gdnative = "0.10"
+gdnative = { git = "https://github.com/godot-rust/godot-rust.git", branch = "master"}
+#gdnative = "0.10"
 egui = "0.18"
 egui-theme = { version = "0.2", optional = true }
 ron = "0.7"

--- a/godot_egui/Cargo.toml
+++ b/godot_egui/Cargo.toml
@@ -12,8 +12,8 @@ readme = "../README.md"
 workspace = ".."
 
 [dependencies]
-gdnative = { git = "https://github.com/godot-rust/godot-rust.git", branch = "master"}
-#gdnative = "0.10"
+gdnative = "0.10.1"
+#gdnative = { git = "https://github.com/godot-rust/godot-rust.git", branch = "master"}
 egui = "0.18"
 egui-theme = { version = "0.2", optional = true }
 ron = "0.7"

--- a/godot_egui/src/lib.rs
+++ b/godot_egui/src/lib.rs
@@ -12,6 +12,7 @@ use gdnative::api::{
 use gdnative::api::File;
 
 use gdnative::export::{hint::EnumHint, Export};
+use gdnative::export::hint::StringHint;
 use gdnative::prelude::*;
 
 /// Contains conversion tables between Godot and egui input constants (keys, mouse buttons)


### PR DESCRIPTION
Updates to latest `gdnative` release and migrates to the new `#[method]` syntax.